### PR TITLE
BaseTimeEntity 추가

### DIFF
--- a/src/main/java/kr/co/lunatalk/domain/common/domain/BaseTimeEntity.java
+++ b/src/main/java/kr/co/lunatalk/domain/common/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package kr.co.lunatalk.domain.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseTimeEntity {
+
+	@CreatedDate
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedBy
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/kr/co/lunatalk/domain/common/domain/BaseTimeEntity.java
+++ b/src/main/java/kr/co/lunatalk/domain/common/domain/BaseTimeEntity.java
@@ -5,7 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -19,6 +19,6 @@ public class BaseTimeEntity {
 	@Column(updatable = false)
 	private LocalDateTime createdAt;
 
-	@LastModifiedBy
+	@LastModifiedDate
 	private LocalDateTime updatedAt;
 }

--- a/src/main/java/kr/co/lunatalk/domain/common/domain/BaseTimeEntity.java
+++ b/src/main/java/kr/co/lunatalk/domain/common/domain/BaseTimeEntity.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 public class BaseTimeEntity {
 
 	@CreatedDate
-	@Column(nullable = false)
+	@Column(updatable = false)
 	private LocalDateTime createdAt;
 
 	@LastModifiedBy

--- a/src/main/java/kr/co/lunatalk/domain/member/domain/Member.java
+++ b/src/main/java/kr/co/lunatalk/domain/member/domain/Member.java
@@ -2,13 +2,8 @@ package kr.co.lunatalk.domain.member.domain;
 
 import jakarta.persistence.*;
 import kr.co.lunatalk.domain.common.domain.BaseTimeEntity;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lombok.*;
+
 
 import java.time.LocalDateTime;
 
@@ -27,6 +22,8 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private String password;
 
+	//TODO: 멤버 기능 만들때 필드 추가 예정
+
     private LocalDateTime lastLoginAt;
 
     @Builder
@@ -38,5 +35,9 @@ public class Member extends BaseTimeEntity {
     public static Member of(String loginId, String password) {
         return Member.builder().loginId(loginId).password(password).build();
     }
+
+	public void updateLastLoginAt() {
+		this.lastLoginAt = LocalDateTime.now();
+	}
 
 }

--- a/src/main/java/kr/co/lunatalk/domain/member/domain/Member.java
+++ b/src/main/java/kr/co/lunatalk/domain/member/domain/Member.java
@@ -1,6 +1,7 @@
 package kr.co.lunatalk.domain.member.domain;
 
 import jakarta.persistence.*;
+import kr.co.lunatalk.domain.common.domain.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,8 +15,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,14 +26,6 @@ public class Member {
 
     @Column(nullable = false)
     private String password;
-
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
 
     private LocalDateTime lastLoginAt;
 
@@ -47,7 +39,4 @@ public class Member {
         return Member.builder().loginId(loginId).password(password).build();
     }
 
-    public void updateLastLoginAt() {
-        this.lastLoginAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/kr/co/lunatalk/global/config/jpa/JpaConfig.java
+++ b/src/main/java/kr/co/lunatalk/global/config/jpa/JpaConfig.java
@@ -1,0 +1,9 @@
+package kr.co.lunatalk.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+#        show_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug

--- a/src/test/java/kr/co/lunatalk/domain/member/domain/MemberTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/member/domain/MemberTest.java
@@ -27,7 +27,6 @@ class MemberTest {
 
 	@Test
 	@DisplayName("멤버 생성일과 수정일 확인")
-	@Rollback(false)
 	void 멤버_정보를_수정했을때_생성일과_수정일은_달라야_한다() {
 		//given
 		Member member = Member.of("test", "test1");

--- a/src/test/java/kr/co/lunatalk/domain/member/domain/MemberTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/member/domain/MemberTest.java
@@ -1,0 +1,51 @@
+package kr.co.lunatalk.domain.member.domain;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import kr.co.lunatalk.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+
+@SpringBootTest
+@Transactional
+class MemberTest {
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@PersistenceContext
+	EntityManager em;
+
+
+	@Test
+	@DisplayName("멤버 생성일과 수정일 확인")
+	@Rollback(false)
+	void 멤버_정보를_수정했을때_생성일과_수정일은_달라야_한다() {
+		//given
+		Member member = Member.of("test", "test1");
+		memberRepository.save(member);
+		member.updateLastLoginAt();
+
+		// when
+		em.flush();
+		em.clear();
+
+		Member findMember = memberRepository.findById(member.getId()).orElseThrow();
+
+		//then
+		System.out.println("member.getCreatedAt() = " + findMember.getCreatedAt());
+		System.out.println("member.getUpdatedAt() = " + findMember.getUpdatedAt());
+		Assertions.assertNotNull(findMember.getCreatedAt());
+		Assertions.assertNotNull(findMember.getUpdatedAt());
+		Assertions.assertNotEquals(findMember.getCreatedAt(), findMember.getUpdatedAt());
+	}
+
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #15 

## 📌 작업 내용
- BaseTimeEntity 추가
- JpaConfig 추가
- BaseTimeEntity 테스트 Member로 테스트 진행

## 📚 기타
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic tracking of creation and modification timestamps for entities.
  - Added configuration to enable JPA auditing features across the application.

- **Refactor**
  - Updated the member entity to inherit timestamp fields from a shared base class, streamlining auditing logic.

- **Tests**
  - Added a test to verify correct behavior of creation and update timestamps when member information is modified.

- **Chores**
  - Added initial application configuration for JPA and Hibernate settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->