### PR TITLE
리프레쉬 토큰 적용 및 테스트 코드, 탈퇴기능

### DIFF
--- a/.github/workflows/develop_pull_request.yml
+++ b/.github/workflows/develop_pull_request.yml
@@ -23,14 +23,9 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle
+        # test 활용 목적의 container 실행
+      - name: Start test docker container
+        run: docker compose -f ./docker-compose-test.yaml up -d
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 
     // FixtureMonkey
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.11")
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  redis:
+    image: "redis:alpine"
+    ports:
+      - "6379:6379"
+    environment:
+      - TZ=Asia/Seoul

--- a/src/main/java/kr/co/lunatalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/lunatalk/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package kr.co.lunatalk.domain.auth.controller;
 
 import jakarta.validation.Valid;
 import kr.co.lunatalk.domain.auth.dto.request.LoginRequest;
+import kr.co.lunatalk.domain.auth.dto.request.RefreshTokenRequest;
 import kr.co.lunatalk.domain.auth.dto.response.AuthTokenResponse;
 import kr.co.lunatalk.domain.auth.service.AuthService;
 import kr.co.lunatalk.domain.member.dto.request.CreateMemberRequest;
@@ -26,5 +27,11 @@ public class AuthController {
 	@PostMapping("/login")
 	public AuthTokenResponse login(@RequestBody @Valid LoginRequest request) {
 		return authService.loginMember(request);
+	}
+
+	// 리프레쉬 토큰으로 액세스 토큰 재발급
+	@PostMapping("/reissue")
+	public AuthTokenResponse reissue(@RequestBody @Valid RefreshTokenRequest request) {
+		return authService.reissueTokenPair(request);
 	}
 }

--- a/src/main/java/kr/co/lunatalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/lunatalk/domain/auth/controller/AuthController.java
@@ -7,10 +7,8 @@ import kr.co.lunatalk.domain.auth.dto.response.AuthTokenResponse;
 import kr.co.lunatalk.domain.auth.service.AuthService;
 import kr.co.lunatalk.domain.member.dto.request.CreateMemberRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -33,5 +31,11 @@ public class AuthController {
 	@PostMapping("/reissue")
 	public AuthTokenResponse reissue(@RequestBody @Valid RefreshTokenRequest request) {
 		return authService.reissueTokenPair(request);
+	}
+
+	@DeleteMapping("/withdraw")
+	public ResponseEntity<Void> withdraw() {
+		authService.withdraw();
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/kr/co/lunatalk/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/kr/co/lunatalk/domain/auth/domain/RefreshToken.java
@@ -1,0 +1,31 @@
+package kr.co.lunatalk.domain.auth.domain;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+	@Id
+	private Long id;
+
+	private String refreshToken;
+
+	@TimeToLive
+	private Long ttl;
+
+	@Builder
+	public RefreshToken(Long id, String refreshToken, Long ttl) {
+		this.id = id;
+		this.refreshToken = refreshToken;
+		this.ttl = ttl;
+	}
+
+	public static RefreshToken of(Long memberId, String refreshToken, Long ttl) {
+		return RefreshToken.builder().id(memberId).refreshToken(refreshToken).ttl(ttl).build();
+	}
+}

--- a/src/main/java/kr/co/lunatalk/domain/auth/dto/AccessTokenDto.java
+++ b/src/main/java/kr/co/lunatalk/domain/auth/dto/AccessTokenDto.java
@@ -2,5 +2,5 @@ package kr.co.lunatalk.domain.auth.dto;
 
 import kr.co.lunatalk.domain.member.domain.MemberRole;
 
-public record TokenDto(Long memberId, MemberRole memberRole) {
+public record AccessTokenDto(Long memberId, MemberRole memberRole) {
 }

--- a/src/main/java/kr/co/lunatalk/domain/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/kr/co/lunatalk/domain/auth/dto/RefreshTokenDto.java
@@ -1,0 +1,6 @@
+package kr.co.lunatalk.domain.auth.dto;
+
+import kr.co.lunatalk.domain.member.domain.MemberRole;
+
+public record RefreshTokenDto(Long memberId, MemberRole memberRole, Long ttl) {
+}

--- a/src/main/java/kr/co/lunatalk/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/kr/co/lunatalk/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,4 @@
+package kr.co.lunatalk.domain.auth.dto.request;
+
+public record RefreshTokenRequest(String refreshToken) {
+}

--- a/src/main/java/kr/co/lunatalk/domain/auth/repository/RefreshRepository.java
+++ b/src/main/java/kr/co/lunatalk/domain/auth/repository/RefreshRepository.java
@@ -1,0 +1,10 @@
+package kr.co.lunatalk.domain.auth.repository;
+
+import kr.co.lunatalk.domain.auth.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshRepository extends CrudRepository<RefreshToken, Long> {
+
+}

--- a/src/main/java/kr/co/lunatalk/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/lunatalk/domain/auth/service/AuthService.java
@@ -63,10 +63,6 @@ public class AuthService {
 
 		Boolean isMatching = matchingPassword(request.password(), member.getPassword());
 
-		System.out.println("isMatching = " + isMatching);
-		System.out.println("request = " + request.password());
-		System.out.println("member.getPassword() = " + member.getPassword());
-
 		if(!isMatching) {
 			throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
 		}

--- a/src/main/java/kr/co/lunatalk/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/kr/co/lunatalk/global/config/security/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package kr.co.lunatalk.global.config.security;
 
-import kr.co.lunatalk.global.security.JwtAuthFilter;
+import kr.co.lunatalk.global.filter.JwtAuthenticationFilter;
+import kr.co.lunatalk.global.security.JwtTokenProvider;
 import kr.co.lunatalk.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -18,7 +19,7 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class WebSecurityConfig {
-	private final JwtUtil jwtUtil;
+	private final JwtTokenProvider jwtTokenProvider;
 
 	@Bean
 	public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -40,13 +41,13 @@ public class WebSecurityConfig {
 				.anyRequest()
 				.permitAll());
 
-		http.addFilterBefore(jwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+		http.addFilterBefore(jwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}
 
 	@Bean
-	public JwtAuthFilter jwtAuthFilter(JwtUtil jwtUtil) {
-		return new JwtAuthFilter(jwtUtil);
+	public JwtAuthenticationFilter jwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+		return new JwtAuthenticationFilter(jwtTokenProvider);
 	}
 }

--- a/src/main/java/kr/co/lunatalk/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/lunatalk/global/exception/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
 	// Auth
 	AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호를 확인해주세요"),
 	AUTH_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보를 찾을수 없습니다."),
-	AUTH_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다.");
+	AUTH_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다."),
+	AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Token이 만료 되었습니다.");
 
 
 	private HttpStatus httpStatus;

--- a/src/main/java/kr/co/lunatalk/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/lunatalk/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 	// Member
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 	MEMBER_EXISTS(HttpStatus.CONFLICT, "존재하는 회원입니다."),
+	MEMBER_ALREADY_DELETED(HttpStatus.CONFLICT, "이미 탈퇴한 회원 입니다."),
 
 	// Auth
 	AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호를 확인해주세요"),

--- a/src/main/java/kr/co/lunatalk/global/security/JwtTokenProvider.java
+++ b/src/main/java/kr/co/lunatalk/global/security/JwtTokenProvider.java
@@ -1,0 +1,46 @@
+package kr.co.lunatalk.global.security;
+
+import kr.co.lunatalk.domain.auth.dto.AccessTokenDto;
+import kr.co.lunatalk.domain.auth.dto.RefreshTokenDto;
+import kr.co.lunatalk.domain.auth.dto.response.TokenResponse;
+import kr.co.lunatalk.domain.member.domain.MemberRole;
+import kr.co.lunatalk.global.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+	private final JwtUtil jwtUtil;
+
+	public TokenResponse generateTokenPair(Long memberId, MemberRole memberRole) {
+		String accessToken = createAccessToken(memberId, memberRole);
+		String refreshToken = createRefreshToken(memberId, memberRole);
+
+		return TokenResponse.of(accessToken, refreshToken);
+	}
+
+	public String createAccessToken(Long memberId, MemberRole memberRole) {
+		return jwtUtil.generateAccessToken(memberId, memberRole);
+	}
+
+	public String createRefreshToken(Long memberId, MemberRole memberRole) {
+		return jwtUtil.generateRefreshToken(memberId, memberRole);
+	}
+
+	public AccessTokenDto parseAccessToken(String token) {
+		try {
+			return jwtUtil.parseAccessToken(token);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	public RefreshTokenDto parseRefreshToken(String token) {
+		try {
+			return jwtUtil.parseRefreshToken(token);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+}

--- a/src/main/java/kr/co/lunatalk/global/security/JwtTokenProvider.java
+++ b/src/main/java/kr/co/lunatalk/global/security/JwtTokenProvider.java
@@ -83,6 +83,6 @@ public class JwtTokenProvider {
 	}
 
 	public void deleteRefreshTokenFromRedis(Long memberId) {
-		refreshRepository.findById(memberId);
+		refreshRepository.deleteById(memberId);
 	}
 }

--- a/src/main/java/kr/co/lunatalk/global/util/JwtUtil.java
+++ b/src/main/java/kr/co/lunatalk/global/util/JwtUtil.java
@@ -94,5 +94,8 @@ public class JwtUtil {
 	}
 
 
+	public Long getRefreshTokenExpirationTime() {
+		return jwtProperties.refreshTokenExpirationTime();
+	}
 
 }

--- a/src/main/java/kr/co/lunatalk/global/util/JwtUtil.java
+++ b/src/main/java/kr/co/lunatalk/global/util/JwtUtil.java
@@ -5,7 +5,8 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import kr.co.lunatalk.domain.auth.dto.TokenDto;
+import kr.co.lunatalk.domain.auth.dto.AccessTokenDto;
+import kr.co.lunatalk.domain.auth.dto.RefreshTokenDto;
 import kr.co.lunatalk.domain.member.domain.MemberRole;
 import kr.co.lunatalk.infra.jwt.JwtProperties;
 import lombok.RequiredArgsConstructor;
@@ -37,11 +38,11 @@ public class JwtUtil {
 		return generateToken(memberId, memberRole, issuedAt, expiredAt, getRefreshTokenKey());
 	}
 
-	public TokenDto parseAccessToken(String token) throws ExpiredJwtException {
+	public AccessTokenDto parseAccessToken(String token) throws ExpiredJwtException {
 		try {
 			Jws<Claims> claims = getClaims(token, getAccessTokenKey());
 
-			return new TokenDto(
+			return new AccessTokenDto(
 				Long.parseLong(claims.getBody().getSubject()),
 				MemberRole.valueOf(claims.getBody().get("role", String.class))
 			);
@@ -52,13 +53,14 @@ public class JwtUtil {
 		}
 	}
 
-	public TokenDto parseRefreshToken(String token) throws ExpiredJwtException {
+	public RefreshTokenDto parseRefreshToken(String token) throws ExpiredJwtException {
 		try {
 			Jws<Claims> claims = getClaims(token, getRefreshTokenKey());
 
-			return new TokenDto(
-				Long.parseLong(claims.getBody().getSubject()),
-				MemberRole.valueOf(claims.getBody().get("role", String.class))
+			return new RefreshTokenDto(
+					Long.parseLong(claims.getBody().getSubject()),
+					MemberRole.valueOf(claims.getBody().get("role", String.class)),
+					jwtProperties.refreshTokenExpirationTime()
 			);
 		} catch (ExpiredJwtException e) {
 			throw e;

--- a/src/main/java/kr/co/lunatalk/global/util/JwtUtil.java
+++ b/src/main/java/kr/co/lunatalk/global/util/JwtUtil.java
@@ -8,14 +8,13 @@ import io.jsonwebtoken.security.Keys;
 import kr.co.lunatalk.domain.auth.dto.AccessTokenDto;
 import kr.co.lunatalk.domain.auth.dto.RefreshTokenDto;
 import kr.co.lunatalk.domain.member.domain.MemberRole;
-import kr.co.lunatalk.infra.jwt.JwtProperties;
+import kr.co.lunatalk.infra.config.jwt.JwtProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
 import java.util.Date;
-import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/kr/co/lunatalk/global/util/MemberUtil.java
+++ b/src/main/java/kr/co/lunatalk/global/util/MemberUtil.java
@@ -1,0 +1,31 @@
+package kr.co.lunatalk.global.util;
+
+import kr.co.lunatalk.domain.member.domain.Member;
+import kr.co.lunatalk.domain.member.repository.MemberRepository;
+import kr.co.lunatalk.global.exception.CustomException;
+import kr.co.lunatalk.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class MemberUtil {
+	private final MemberRepository memberRepository;
+	private final SecurityUtil securityUtil;
+
+	@Transactional(readOnly = true)
+	public Member getCurrentMember() {
+		return memberRepository
+			.findById(securityUtil.getCurrentMemberId())
+			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+	}
+
+	@Transactional(readOnly = true)
+	public Member getMemberByMemberId(Long memberId) {
+		return memberRepository
+			.findById(memberId)
+			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+	}
+
+}

--- a/src/main/java/kr/co/lunatalk/infra/config/jwt/JwtProperties.java
+++ b/src/main/java/kr/co/lunatalk/infra/config/jwt/JwtProperties.java
@@ -1,4 +1,4 @@
-package kr.co.lunatalk.infra.jwt;
+package kr.co.lunatalk.infra.config.jwt;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/kr/co/lunatalk/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/kr/co/lunatalk/infra/config/properties/PropertiesConfig.java
@@ -1,6 +1,6 @@
-package kr.co.lunatalk.infra.properties;
+package kr.co.lunatalk.infra.config.properties;
 
-import kr.co.lunatalk.infra.jwt.JwtProperties;
+import kr.co.lunatalk.infra.config.jwt.JwtProperties;
 import kr.co.lunatalk.infra.config.redis.RedisProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/kr/co/lunatalk/infra/config/redis/RedisConfig.java
+++ b/src/main/java/kr/co/lunatalk/infra/config/redis/RedisConfig.java
@@ -18,9 +18,9 @@ public class RedisConfig {
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisProperties.host(), redisProperties.port());
-		if(!redisProperties.password().isBlank()) {
-			redisConfig.setPassword(redisProperties.password());
-		}
+//		if(!redisProperties.password().isBlank()) {
+//			redisConfig.setPassword(redisProperties.password());
+//		}
 		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
 			.commandTimeout(Duration.ofSeconds(1))
 			.shutdownTimeout(Duration.ZERO)

--- a/src/main/java/kr/co/lunatalk/infra/config/redis/RedisConfig.java
+++ b/src/main/java/kr/co/lunatalk/infra/config/redis/RedisConfig.java
@@ -4,7 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.time.Duration;
 
 @Configuration
 @RequiredArgsConstructor
@@ -13,6 +17,14 @@ public class RedisConfig {
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(redisProperties.host(), redisProperties.port());
+		RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisProperties.host(), redisProperties.port());
+		if(!redisProperties.password().isBlank()) {
+			redisConfig.setPassword(redisProperties.password());
+		}
+		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+			.commandTimeout(Duration.ofSeconds(1))
+			.shutdownTimeout(Duration.ZERO)
+			.build();
+		return new LettuceConnectionFactory(redisConfig, clientConfig);
 	}
 }

--- a/src/main/java/kr/co/lunatalk/infra/config/redis/RedisConfig.java
+++ b/src/main/java/kr/co/lunatalk/infra/config/redis/RedisConfig.java
@@ -1,0 +1,18 @@
+package kr.co.lunatalk.infra.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+	private final RedisProperties redisProperties;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisProperties.host(), redisProperties.port());
+	}
+}

--- a/src/main/java/kr/co/lunatalk/infra/config/redis/RedisProperties.java
+++ b/src/main/java/kr/co/lunatalk/infra/config/redis/RedisProperties.java
@@ -1,0 +1,7 @@
+package kr.co.lunatalk.infra.config.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "redis")
+public record RedisProperties(String host, int port, String database, String password) {
+}

--- a/src/main/java/kr/co/lunatalk/infra/config/redis/RedisProperties.java
+++ b/src/main/java/kr/co/lunatalk/infra/config/redis/RedisProperties.java
@@ -2,6 +2,6 @@ package kr.co.lunatalk.infra.config.redis;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "redis")
-public record RedisProperties(String host, int port, String database, String password) {
+@ConfigurationProperties(prefix = "spring.data.redis")
+public record RedisProperties(String host, int port) {
 }

--- a/src/main/java/kr/co/lunatalk/infra/properties/PropertiesConfig.java
+++ b/src/main/java/kr/co/lunatalk/infra/properties/PropertiesConfig.java
@@ -1,10 +1,11 @@
 package kr.co.lunatalk.infra.properties;
 
 import kr.co.lunatalk.infra.jwt.JwtProperties;
+import kr.co.lunatalk.infra.config.redis.RedisProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@EnableConfigurationProperties({JwtProperties.class})
+@EnableConfigurationProperties({JwtProperties.class, RedisProperties.class})
 @Configuration
 public class PropertiesConfig {
 }

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,6 @@
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,6 +1,6 @@
 spring:
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-      password: ${REDIS_PASSWORD}
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,12 +2,11 @@ spring:
   profiles:
     group:
       local: "local"
-      dev: "dev"
-      prod: "prod"
+      dev: "dev datasource"
+      prod: "prod datasource"
     include:
       - security
       - actuator
-      - datasource
       - redis
 #spring:
 #  jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
       - security
       - actuator
       - datasource
+      - redis
 #spring:
 #  jpa:
 #    hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,20 +2,9 @@ spring:
   profiles:
     group:
       local: "local"
-      dev: "dev datasource"
-      prod: "prod datasource"
+      dev: "dev, datasource"
+      prod: "prod, datasource"
     include:
       - security
       - actuator
       - redis
-#spring:
-#  jpa:
-#    hibernate:
-#      ddl-auto: create
-#    properties:
-#      hibernate:
-#        format_sql: true
-##        show_sql: true
-#
-#logging.level:
-#  org.hibernate.SQL: debug

--- a/src/test/java/kr/co/lunatalk/FixtureMonkeySetUp.java
+++ b/src/test/java/kr/co/lunatalk/FixtureMonkeySetUp.java
@@ -1,0 +1,21 @@
+package kr.co.lunatalk;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FixtureMonkeySetUp {
+
+	protected FixtureMonkey fixtureMonkey;
+
+	@BeforeEach
+	void setUp() {
+		fixtureMonkey = FixtureMonkey.builder()
+			.objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+			.defaultNotNull(true)
+			.build();
+	}
+}

--- a/src/test/java/kr/co/lunatalk/TestRedisConfig.java
+++ b/src/test/java/kr/co/lunatalk/TestRedisConfig.java
@@ -1,0 +1,13 @@
+package kr.co.lunatalk;
+
+import kr.co.lunatalk.infra.config.redis.RedisConfig;
+import kr.co.lunatalk.infra.config.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@TestConfiguration
+@EnableConfigurationProperties({RedisProperties.class})
+@Import(RedisConfig.class)
+public class TestRedisConfig {,lpp
+}

--- a/src/test/java/kr/co/lunatalk/TestRedisConfig.java
+++ b/src/test/java/kr/co/lunatalk/TestRedisConfig.java
@@ -9,5 +9,5 @@ import org.springframework.context.annotation.Import;
 @TestConfiguration
 @EnableConfigurationProperties({RedisProperties.class})
 @Import(RedisConfig.class)
-public class TestRedisConfig {,lpp
+public class TestRedisConfig {
 }

--- a/src/test/java/kr/co/lunatalk/domain/auth/repository/RefreshRepositoryTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/auth/repository/RefreshRepositoryTest.java
@@ -1,67 +1,67 @@
-//package kr.co.lunatalk.domain.auth.repository;
-//
-//import kr.co.lunatalk.TestRedisConfig;
-//import kr.co.lunatalk.domain.auth.domain.RefreshToken;
-//import org.assertj.core.api.Assertions;
-//import org.junit.jupiter.api.AfterEach;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
-//import org.springframework.context.annotation.Import;
-//import org.springframework.test.context.ActiveProfiles;
-//
-//import java.util.Optional;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//
-//@ActiveProfiles("test")
-//@Import(TestRedisConfig.class)
-//@DataRedisTest
-//class RefreshRepositoryTest {
-//
-//	@Autowired RefreshRepository refreshRepository;
-//
-//	@AfterEach
-//	void tearDown() {
-//		refreshRepository.deleteAll();
-//	}
-//
-//	@Test
-//	void 리프레쉬_토큰을_저장한다(){
-//		//given
-//		RefreshToken refreshToken = RefreshToken.builder().id(1L).refreshToken("testRefreshToken").ttl(1000L).build();
-//		//when
-//		refreshRepository.save(refreshToken);
-//		//then
-//		Optional<RefreshToken> findById = refreshRepository.findById(1L);
-//
-//		assertThat(findById.isPresent()).isTrue();
-//	}
-//
-//	@Test
-//	void 리프레쉬_토큰을_삭제한다() {
-//		//given
-//		RefreshToken refreshToken = RefreshToken.builder().id(2L).refreshToken("testRefreshToken").ttl(1000L).build();
-//		refreshRepository.save(refreshToken);
-//		//when
-//		refreshRepository.deleteById(2L);
-//		//then
-//		assertThat(refreshRepository.findById(2L).isPresent()).isFalse();
-//	}
-//
-//	@Test
-//	void 리프레쉬_토큰을_조회한다() {
-//		//given
-//		RefreshToken refreshToken = RefreshToken.builder().id(3L).refreshToken("testRefreshToken").ttl(1000L).build();
-//		refreshRepository.save(refreshToken);
-//
-//		//when
-//		Optional<RefreshToken> findById = refreshRepository.findById(3L);
-//		//then
-//		assertThat(findById.isPresent()).isTrue();
-//		assertThat(3L).isEqualTo(findById.get().getId());
-//		assertThat("testRefreshToken").isEqualTo(findById.get().getRefreshToken());
-//	}
-//}
+package kr.co.lunatalk.domain.auth.repository;
+
+import kr.co.lunatalk.TestRedisConfig;
+import kr.co.lunatalk.domain.auth.domain.RefreshToken;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ActiveProfiles("test")
+@Import(TestRedisConfig.class)
+@DataRedisTest
+class RefreshRepositoryTest {
+
+	@Autowired RefreshRepository refreshRepository;
+
+	@AfterEach
+	void tearDown() {
+		refreshRepository.deleteAll();
+	}
+
+	@Test
+	void 리프레쉬_토큰을_저장한다(){
+		//given
+		RefreshToken refreshToken = RefreshToken.builder().id(1L).refreshToken("testRefreshToken").ttl(1000L).build();
+		//when
+		refreshRepository.save(refreshToken);
+		//then
+		Optional<RefreshToken> findById = refreshRepository.findById(1L);
+
+		assertThat(findById.isPresent()).isTrue();
+	}
+
+	@Test
+	void 리프레쉬_토큰을_삭제한다() {
+		//given
+		RefreshToken refreshToken = RefreshToken.builder().id(2L).refreshToken("testRefreshToken").ttl(1000L).build();
+		refreshRepository.save(refreshToken);
+		//when
+		refreshRepository.deleteById(2L);
+		//then
+		assertThat(refreshRepository.findById(2L).isPresent()).isFalse();
+	}
+
+	@Test
+	void 리프레쉬_토큰을_조회한다() {
+		//given
+		RefreshToken refreshToken = RefreshToken.builder().id(3L).refreshToken("testRefreshToken").ttl(1000L).build();
+		refreshRepository.save(refreshToken);
+
+		//when
+		Optional<RefreshToken> findById = refreshRepository.findById(3L);
+		//then
+		assertThat(findById.isPresent()).isTrue();
+		assertThat(3L).isEqualTo(findById.get().getId());
+		assertThat("testRefreshToken").isEqualTo(findById.get().getRefreshToken());
+	}
+}

--- a/src/test/java/kr/co/lunatalk/domain/auth/repository/RefreshRepositoryTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/auth/repository/RefreshRepositoryTest.java
@@ -1,67 +1,67 @@
-package kr.co.lunatalk.domain.auth.repository;
-
-import kr.co.lunatalk.TestRedisConfig;
-import kr.co.lunatalk.domain.auth.domain.RefreshToken;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-
-
-@ActiveProfiles("test")
-@Import(TestRedisConfig.class)
-@DataRedisTest
-class RefreshRepositoryTest {
-
-	@Autowired RefreshRepository refreshRepository;
-
-	@AfterEach
-	void tearDown() {
-		refreshRepository.deleteAll();
-	}
-
-	@Test
-	void 리프레쉬_토큰을_저장한다(){
-		//given
-		RefreshToken refreshToken = RefreshToken.builder().id(1L).refreshToken("testRefreshToken").ttl(1000L).build();
-		//when
-		refreshRepository.save(refreshToken);
-		//then
-		Optional<RefreshToken> findById = refreshRepository.findById(1L);
-
-		assertThat(findById.isPresent()).isTrue();
-	}
-
-	@Test
-	void 리프레쉬_토큰을_삭제한다() {
-		//given
-		RefreshToken refreshToken = RefreshToken.builder().id(2L).refreshToken("testRefreshToken").ttl(1000L).build();
-		refreshRepository.save(refreshToken);
-		//when
-		refreshRepository.deleteById(2L);
-		//then
-		assertThat(refreshRepository.findById(2L).isPresent()).isFalse();
-	}
-
-	@Test
-	void 리프레쉬_토큰을_조회한다() {
-		//given
-		RefreshToken refreshToken = RefreshToken.builder().id(3L).refreshToken("testRefreshToken").ttl(1000L).build();
-		refreshRepository.save(refreshToken);
-
-		//when
-		Optional<RefreshToken> findById = refreshRepository.findById(3L);
-		//then
-		assertThat(findById.isPresent()).isTrue();
-		assertThat(3L).isEqualTo(findById.get().getId());
-		assertThat("testRefreshToken").isEqualTo(findById.get().getRefreshToken());
-	}
-}
+//package kr.co.lunatalk.domain.auth.repository;
+//
+//import kr.co.lunatalk.TestRedisConfig;
+//import kr.co.lunatalk.domain.auth.domain.RefreshToken;
+//import org.assertj.core.api.Assertions;
+//import org.junit.jupiter.api.AfterEach;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+//import org.springframework.context.annotation.Import;
+//import org.springframework.test.context.ActiveProfiles;
+//
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//
+//@ActiveProfiles("test")
+//@Import(TestRedisConfig.class)
+//@DataRedisTest
+//class RefreshRepositoryTest {
+//
+//	@Autowired RefreshRepository refreshRepository;
+//
+//	@AfterEach
+//	void tearDown() {
+//		refreshRepository.deleteAll();
+//	}
+//
+//	@Test
+//	void 리프레쉬_토큰을_저장한다(){
+//		//given
+//		RefreshToken refreshToken = RefreshToken.builder().id(1L).refreshToken("testRefreshToken").ttl(1000L).build();
+//		//when
+//		refreshRepository.save(refreshToken);
+//		//then
+//		Optional<RefreshToken> findById = refreshRepository.findById(1L);
+//
+//		assertThat(findById.isPresent()).isTrue();
+//	}
+//
+//	@Test
+//	void 리프레쉬_토큰을_삭제한다() {
+//		//given
+//		RefreshToken refreshToken = RefreshToken.builder().id(2L).refreshToken("testRefreshToken").ttl(1000L).build();
+//		refreshRepository.save(refreshToken);
+//		//when
+//		refreshRepository.deleteById(2L);
+//		//then
+//		assertThat(refreshRepository.findById(2L).isPresent()).isFalse();
+//	}
+//
+//	@Test
+//	void 리프레쉬_토큰을_조회한다() {
+//		//given
+//		RefreshToken refreshToken = RefreshToken.builder().id(3L).refreshToken("testRefreshToken").ttl(1000L).build();
+//		refreshRepository.save(refreshToken);
+//
+//		//when
+//		Optional<RefreshToken> findById = refreshRepository.findById(3L);
+//		//then
+//		assertThat(findById.isPresent()).isTrue();
+//		assertThat(3L).isEqualTo(findById.get().getId());
+//		assertThat("testRefreshToken").isEqualTo(findById.get().getRefreshToken());
+//	}
+//}

--- a/src/test/java/kr/co/lunatalk/domain/auth/repository/RefreshRepositoryTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/auth/repository/RefreshRepositoryTest.java
@@ -1,0 +1,67 @@
+package kr.co.lunatalk.domain.auth.repository;
+
+import kr.co.lunatalk.TestRedisConfig;
+import kr.co.lunatalk.domain.auth.domain.RefreshToken;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ActiveProfiles("test")
+@Import(TestRedisConfig.class)
+@DataRedisTest
+class RefreshRepositoryTest {
+
+	@Autowired RefreshRepository refreshRepository;
+
+	@AfterEach
+	void tearDown() {
+		refreshRepository.deleteAll();
+	}
+
+	@Test
+	void 리프레쉬_토큰을_저장한다(){
+		//given
+		RefreshToken refreshToken = RefreshToken.builder().id(1L).refreshToken("testRefreshToken").ttl(1000L).build();
+		//when
+		refreshRepository.save(refreshToken);
+		//then
+		Optional<RefreshToken> findById = refreshRepository.findById(1L);
+
+		assertThat(findById.isPresent()).isTrue();
+	}
+
+	@Test
+	void 리프레쉬_토큰을_삭제한다() {
+		//given
+		RefreshToken refreshToken = RefreshToken.builder().id(2L).refreshToken("testRefreshToken").ttl(1000L).build();
+		refreshRepository.save(refreshToken);
+		//when
+		refreshRepository.deleteById(2L);
+		//then
+		assertThat(refreshRepository.findById(2L).isPresent()).isFalse();
+	}
+
+	@Test
+	void 리프레쉬_토큰을_조회한다() {
+		//given
+		RefreshToken refreshToken = RefreshToken.builder().id(3L).refreshToken("testRefreshToken").ttl(1000L).build();
+		refreshRepository.save(refreshToken);
+
+		//when
+		Optional<RefreshToken> findById = refreshRepository.findById(3L);
+		//then
+		assertThat(findById.isPresent()).isTrue();
+		assertThat(3L).isEqualTo(findById.get().getId());
+		assertThat("testRefreshToken").isEqualTo(findById.get().getRefreshToken());
+	}
+}

--- a/src/test/java/kr/co/lunatalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/auth/service/AuthServiceTest.java
@@ -75,7 +75,8 @@ class AuthServiceTest {
 		Member member = Member.of("login", "password", Profile.of("", ""));
 		when(memberRepository.findByUsername("login")).thenReturn(Optional.of(member));
 
-		when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+//		when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+		doReturn(true).when(passwordEncoder).matches(anyString(), anyString());
 
 		when(jwtTokenProvider.generateTokenPair(member.getId(), member.getRole())).thenReturn(new TokenResponse("accessToken", "refreshToken"));
 		AuthTokenResponse response = authService.loginMember(new LoginRequest("login", "password"));

--- a/src/test/java/kr/co/lunatalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/auth/service/AuthServiceTest.java
@@ -73,7 +73,6 @@ class AuthServiceTest {
 	@Test
 	void 로그인() {
 		Member member = Member.of("login", "password", Profile.of("", ""));
-		System.out.println("member = " + member);
 		when(memberRepository.findByUsername("login")).thenReturn(Optional.of(member));
 
 		when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);

--- a/src/test/java/kr/co/lunatalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/auth/service/AuthServiceTest.java
@@ -6,19 +6,24 @@ import kr.co.lunatalk.domain.auth.dto.response.AuthTokenResponse;
 import kr.co.lunatalk.domain.auth.dto.response.TokenResponse;
 import kr.co.lunatalk.domain.member.domain.Member;
 import kr.co.lunatalk.domain.member.domain.MemberRole;
+import kr.co.lunatalk.domain.member.domain.MemberStatus;
 import kr.co.lunatalk.domain.member.domain.Profile;
 import kr.co.lunatalk.domain.member.dto.request.CreateMemberRequest;
 import kr.co.lunatalk.domain.member.repository.MemberRepository;
 import kr.co.lunatalk.global.exception.CustomException;
+import kr.co.lunatalk.global.exception.ErrorCode;
 import kr.co.lunatalk.global.security.JwtTokenProvider;
+import kr.co.lunatalk.global.util.MemberUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
@@ -35,11 +40,14 @@ class AuthServiceTest {
 	@Mock
 	MemberRepository memberRepository;
 
-	@Mock
-	PasswordEncoder passwordEncoder;
+	@Spy
+	PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
 	@Mock
 	JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	MemberUtil memberUtil;
 
 	@InjectMocks
 	AuthService authService;
@@ -65,7 +73,10 @@ class AuthServiceTest {
 	@Test
 	void 로그인() {
 		Member member = Member.of("login", "password", Profile.of("", ""));
+		System.out.println("member = " + member);
 		when(memberRepository.findByUsername("login")).thenReturn(Optional.of(member));
+
+		when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
 
 		when(jwtTokenProvider.generateTokenPair(member.getId(), member.getRole())).thenReturn(new TokenResponse("accessToken", "refreshToken"));
 		AuthTokenResponse response = authService.loginMember(new LoginRequest("login", "password"));
@@ -73,5 +84,42 @@ class AuthServiceTest {
 		assertNotNull(response);
 		assertEquals("accessToken", response.accessToken());
 		assertEquals("refreshToken", response.refreshToken());
+	}
+
+	@Test
+	void 탈퇴_기능() {
+		Member member = Member.of("withdraw", "password", Profile.of("", ""));
+
+		when(memberUtil.getCurrentMember()).thenReturn(member);
+
+		doAnswer(
+			invocationOnMock -> {
+				member.withdrawal();
+				return null;
+			}
+		).when(memberRepository).deleteById(member.getId());
+
+		authService.withdraw();
+
+		assertEquals(MemberStatus.DELETE, member.getStatus());
+
+	}
+
+	@Test
+	@DisplayName("로그인 실패 - 비밀번호 불일치")
+	void 로그인_비밀번호불일치() {
+		// given
+		String rawPassword = "wrong-password"; // 로그인 요청 비번
+		String encodedPassword = passwordEncoder.encode("real-password"); // 저장된 비번 (암호화)
+
+		Member member = Member.of("loginUser", encodedPassword, Profile.of("", ""));
+
+		when(memberRepository.findByUsername("loginUser")).thenReturn(Optional.of(member));
+		// when & then
+		CustomException exception = assertThrows(CustomException.class, () -> {
+			authService.loginMember(new LoginRequest("loginUser", rawPassword));
+		});
+
+		assertEquals(ErrorCode.AUTH_UNAUTHORIZED, exception.getErrorCode());
 	}
 }

--- a/src/test/java/kr/co/lunatalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,69 @@
+package kr.co.lunatalk.domain.auth.service;
+
+import kr.co.lunatalk.FixtureMonkeySetUp;
+import kr.co.lunatalk.TestRedisConfig;
+import kr.co.lunatalk.domain.auth.dto.request.LoginRequest;
+import kr.co.lunatalk.domain.auth.dto.response.AuthTokenResponse;
+import kr.co.lunatalk.domain.member.domain.Member;
+import kr.co.lunatalk.domain.member.domain.Profile;
+import kr.co.lunatalk.domain.member.repository.MemberRepository;
+import kr.co.lunatalk.infra.config.redis.RedisProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ActiveProfiles("test")
+@Import({TestRedisConfig.class})
+@DataRedisTest
+class AuthServiceTest extends FixtureMonkeySetUp {
+
+	@Autowired
+	private AuthService authService;
+	@Autowired private MemberRepository memberRepository;
+
+	String username;
+	String password;
+
+	@BeforeEach
+	void setUp() {
+		username = fixtureMonkey.giveMeOne(String.class);
+		password = fixtureMonkey.giveMeOne(String.class);
+	}
+
+	@Test
+	void 일반_로그인() {
+		//given
+
+		Member member = Member.of(username, password, Profile.of("test", "test"));
+		memberRepository.save(member);
+		//when
+		AuthTokenResponse authTokenResponse = authService.loginMember(new LoginRequest(username, password));
+		//then
+		assertNotNull(authTokenResponse.accessToken());
+		assertNotNull(authTokenResponse.refreshToken());
+	}
+
+	@Test
+	void 회원가입() {
+
+	}
+
+	@Test
+	void 틸퇴() {
+
+	}
+
+	@Test
+	void 토큰_재발급() {
+
+	}
+}

--- a/src/test/java/kr/co/lunatalk/domain/member/domain/MemberTest.java
+++ b/src/test/java/kr/co/lunatalk/domain/member/domain/MemberTest.java
@@ -66,9 +66,7 @@ class MemberTest {
 		Member member = fixtureMonkey.giveMeOne(Member.class);
 		Profile newProfile = fixtureMonkey.giveMeOne(Profile.class);
 		// when
-		System.out.println("member.getProfile() = " + member.getProfile());
 		member.updateProfile(newProfile);
-		System.out.println("member.getProfile() = " + member.getProfile());
 		// then
 		assertEquals(newProfile, member.getProfile());
 	}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  config:
+    activate:
+      on-profile: "test"
+
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALS
+
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
+

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "test"
 
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALS
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
   jpa:
     properties:


### PR DESCRIPTION
## 🌱 관련 이슈

- close #20 

## 📌 작업 내용
- 탈퇴기능 추가, 리프레쉬 토큰 기능 추가, 테스트 케이스 추가

## 📚 기타
- 테스트 케이스는 현재 공부중이므로, 점점 늘어날거 같음!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Redis integration with new configuration and properties.
  - Introduced refresh token management with endpoints for token reissue and user withdrawal.
  - Added classes for access and refresh token handling, including Redis storage and validation.
  - Enhanced security with updated JWT token provider and authentication filter.
- **Bug Fixes**
  - Added error codes for expired tokens and already withdrawn members.
- **Refactor**
  - Refactored authentication service and security configuration for improved token management.
- **Tests**
  - Added tests for refresh token repository and authentication service.
  - Introduced Redis test configuration and fixture setup.
- **Chores**
  - Updated application profiles and added Redis-related configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->